### PR TITLE
Don't list pytest and mock as install_requires.

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,6 +1,4 @@
 lxml
 tifffile>2020.10.1
 numpy
-pytest
-mock
 imagecodecs


### PR DESCRIPTION
They are only needed in a dev environment, not for end users.

(Note that there are various ways in which one could avoid the duplication between install_requires and the requirements file, e.g. splitting out the dev requirements in a separate requirements file, but I just went for the simpler and more practical approach here.)