### PR TITLE
Patch metadata logging

### DIFF
--- a/pyometiff/omereader.py
+++ b/pyometiff/omereader.py
@@ -127,7 +127,7 @@ class OMETIFFReader:
         try:
             metadata["InstrumentID"] = self.ox.instrument(self.imageseries).get_ID()
         except (KeyError, AttributeError, IndexError) as e:
-            logging.warning(f"InstrumentID missing in metadata: {e}")
+            logging.warning(f"InstrumentID missing in metadata for {self.fpath.name}: {e}")
             metadata["InstrumentID"] = None
         
         try:
@@ -141,7 +141,7 @@ class OMETIFFReader:
                 self.imageseries
             ).Detector.get_Type()
         except (KeyError, AttributeError, IndexError) as e:
-            logging.warning(f"Detector metadata missing or incomplete: {e}")
+            logging.warning(f"Detector metadata missing or incomplete for {self.fpath.name}: {e}")
             metadata["DetectorModel"] = None
             metadata["DetectorID"] = None
             metadata["DetectorType"] = None
@@ -151,7 +151,7 @@ class OMETIFFReader:
                 self.imageseries
             ).Microscope.get_Type()
         except (KeyError, AttributeError, IndexError) as e:
-            logging.warning(f"MicroscopeType metadata missing: {e}")
+            logging.warning(f"MicroscopeType metadata missing for {self.fpath.name}: {e}")
 
         try:
             metadata["ObjNA"] = self.ox.instrument(
@@ -162,7 +162,7 @@ class OMETIFFReader:
                 self.imageseries
             ).Objective.get_NominalMagnification()
         except (KeyError, AttributeError, IndexError) as e:
-            logging.warning(f"Objective metadata incomplete: {e}")
+            logging.warning(f"Objective metadata incomplete for {self.fpath.name}: {e}")
             metadata["ObjNA"] = None
             metadata["ObjID"] = None
             metadata["ObjMag"] = None

--- a/pyometiff/omereader.py
+++ b/pyometiff/omereader.py
@@ -141,7 +141,7 @@ class OMETIFFReader:
                 self.imageseries
             ).Detector.get_Type()
         except (KeyError, AttributeError, IndexError) as e:
-            print("Key not found:", e)
+            logging.warning(f"Detector metadata missing or incomplete: {e}")
             metadata["DetectorModel"] = None
             metadata["DetectorID"] = None
             metadata["DetectorType"] = None

--- a/pyometiff/omereader.py
+++ b/pyometiff/omereader.py
@@ -127,8 +127,9 @@ class OMETIFFReader:
         try:
             metadata["InstrumentID"] = self.ox.instrument(self.imageseries).get_ID()
         except (KeyError, AttributeError, IndexError) as e:
-            print("Key not found:", e)
+            logging.warning(f"InstrumentID missing in metadata: {e}")
             metadata["InstrumentID"] = None
+        
         try:
             metadata["DetectorModel"] = self.ox.instrument(
                 self.imageseries

--- a/pyometiff/omereader.py
+++ b/pyometiff/omereader.py
@@ -162,7 +162,7 @@ class OMETIFFReader:
                 self.imageseries
             ).Objective.get_NominalMagnification()
         except (KeyError, AttributeError, IndexError) as e:
-            print("Key not found:", e)
+            logging.warning(f"Objective metadata incomplete: {e}")
             metadata["ObjNA"] = None
             metadata["ObjID"] = None
             metadata["ObjMag"] = None

--- a/pyometiff/omereader.py
+++ b/pyometiff/omereader.py
@@ -151,7 +151,7 @@ class OMETIFFReader:
                 self.imageseries
             ).Microscope.get_Type()
         except (KeyError, AttributeError, IndexError) as e:
-            print("key not found", e)
+            logging.warning(f"MicroscopeType metadata missing: {e}")
 
         try:
             metadata["ObjNA"] = self.ox.instrument(


### PR DESCRIPTION
refactor `print` statements to use `logging.warning`.

since you already use `logging.warning` in https://github.com/filippocastelli/pyometiff/blob/ecd28ba8ad0f605f7d38b7ac06be4fde5fb3241b/pyometiff/omereader.py#L52